### PR TITLE
DM-10923: Pass retry_request arguments through Travis webhook methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = 'TravisCI Python interaction class'
 AUTHOR = 'Adam Thornton'
 AUTHOR_EMAIL = 'athornton@lsst.org'
 URL = 'https://github.com/sqre-lsst/travisci'
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 LICENSE = 'MIT'
 
 


### PR DESCRIPTION
This gives the API user control over how retries are done. It seems that the Travis sync benefits from a longer retry interval, so this makes that possible.
